### PR TITLE
Removed unused import

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -2,13 +2,13 @@ package influxdbv2
 
 import (
 	"errors"
+	"os"
+
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/api/write"
 	"github.com/loadimpact/k6/output"
 	"github.com/loadimpact/k6/stats"
-	"os"
-	"time"
 )
 
 func init() {


### PR DESCRIPTION
`time` wasn't used, so the extension couldn't compile